### PR TITLE
User site pakage

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -50,7 +50,7 @@ sudo cp $abaddonPATH/nmaptocsv/nmaptocsv.py /usr/local/bin/nmaptocsv
 
 echo -e "\n\nPATCHING SIX\n\n"
 #Patch one dependencie, and add ~/.local/bin to PATH
-sed -i 's/django.utils.six/six/g' ~/.local/lib/python3.7/site-packages/datetimewidget/widgets.py
+sed -i 's/django.utils.six/six/g' $(python3 -m site --user-site)/datetimewidget/widgets.py
 echo -e "export PATH=\$PATH:~/.local/bin" >> ~/.bashrc
 #Other dependencies
 


### PR DESCRIPTION
The per user site-packages directory (PEP 370) is where Python installs your local packages.
It can be different depending on various system configuration.
If it's not set correctly, the setup script will fail.

This modification will get dynamically the user PEP 370.
