### PR TITLE
Update deploy scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,10 @@ db.sqlite3
 
 *.key
 *.keys
+
+# Abaddon spesifics
+nmaptocsv/
+setup/nmaptocsv/
+exploitation/migrations/0001_initial.py
+settings/migrations/0002_auto_20200327_1132.py
+dashboard/migrations/0001_initial.py

--- a/ansible/roles/gophish/tasks/main.yml
+++ b/ansible/roles/gophish/tasks/main.yml
@@ -1,3 +1,7 @@
+#- name: "Ansible | List all known variables and facts"
+#  debug:
+#    var: hostvars[inventory_hostname]
+
 - name: Check if the password is defined
   stat:
     path: /home/{{ gophish_user }}/password.txt
@@ -6,17 +10,29 @@
 - copy: 
     content: "{{ gophish_pass }}" 
     dest: /home/{{ gophish_user }}/password.txt
-  when: password_set.stat.exists == False
+  when: password_set.stat.exists == false
 
 - name: Read pwd
   slurp:
     src: /home/{{ gophish_user }}/password.txt
   register: pwd
 
-- debug: 
-    msg: "The admin password is : {{ pwd['content'] }}"
-#  when: password_set.stat.exists == False
+- set_fact:
+    gophish_pass: "{{ pwd['content'] | b64decode }}"
 
+- debug: 
+    msg: "The admin password is : {{ gophish_pass }}"
+
+
+- copy: 
+    content: "{{ gophish_pass }}" 
+    dest: /home/{{ gophish_user }}/password.txt
+  when: password_set.stat.exists == false
+
+- fetch: 
+    dest: "/tmp/{{ uuid }}.txt" 
+    src: /home/{{ gophish_user }}/password.txt
+    flat: yes
 
 - name: Change /etc/hostname
   hostname:
@@ -60,6 +76,7 @@
 - name: Install specified packages.
   apt:
     pkg: "{{ install_packages }}"
+    update_cache: yes
     state: latest
 
 - name: Update postfix main.cf configuration file.
@@ -159,4 +176,4 @@
     creates: "/home/{{ gophish_user }}/password_enc"
 
 - debug: 
-    msg: "The password is : {{ pwd['content'] }}"
+    msg: "The password is : {{ gophish_pass }}"

--- a/ansible/roles/gophish/templates/password.sh.j2
+++ b/ansible/roles/gophish/templates/password.sh.j2
@@ -3,5 +3,5 @@
 cd /home/{{ gophish_user }}/gophish/
 ./gophish &
 sleep 30
-python2 -c "import bcrypt; print(bcrypt.hashpw('{{ pwd['content'] }}', bcrypt.gensalt(10)))" > /home/{{ gophish_user }}/password_enc
+python2 -c "import bcrypt; print(bcrypt.hashpw('{{ gophish_pass }}', bcrypt.gensalt(10)))" > /home/{{ gophish_user }}/password_enc
 sqlite3 /home/{{ gophish_user }}/gophish/gophish.db "update users set hash=\"$(cat /home/{{ gophish_user }}/password_enc)\" where username='admin';"

--- a/deploy.py
+++ b/deploy.py
@@ -1,0 +1,52 @@
+from python_terraform import *
+import uuid
+import argparse
+
+curr_path=os.path.abspath(os.path.dirname(sys.argv[0]))
+
+
+parser = argparse.ArgumentParser()
+#group = parser.add_mutually_exclusive_group()
+parser.add_argument("-a", "--apply", action="store_true", help="Create a new gophish infrastructure")
+#group.add_argument("-d", "--destroy", action="store_true")
+parser.add_argument('-d','--destroy', nargs='?', help="Destroy a gophish infra (the ec2 uuid has to be given)" )
+args = parser.parse_args()
+
+
+def get_env():
+    t = Terraform()
+    return [i[2:] for i in t.cmd('workspace list')[1].split('\n') if i.startswith('ec2_',2)]
+
+def create_uuid():
+    return 'ec2_'+str(uuid.uuid4())
+
+def print_env():
+    print(*get_env(), sep = "\n")
+
+def deploy_ec2(uuid, path):
+    print('------------- Creating : ', uuid,' ----------------')
+    t = Terraform(working_dir=path)
+    if t.create_workspace(uuid)[0] != 0:
+        t.set_workspace(uuid)
+    t.apply(path, skip_plan=True ,capture_output=False)
+    return t.cmd('output -json public_ip | sed s/\"//g')
+
+def destroy_ec2(uuid, path):
+    print('------------- Destroying : ', uuid,' ----------------')
+    t = Terraform(working_dir=path)
+    if t.set_workspace('tree')[0] == 1:
+        t.destroy(path ,capture_output=False)
+    else:
+        print('Unable to destroy instance, workspace does not exsist.')
+
+
+terraform_path = curr_path + "/terraform/aws"
+if args.destroy:
+  destroy_ec2(args.destroy, terraform_path)
+if args.apply:
+  uuid=create_uuid()
+  ip = deploy_ec2(uuid, terraform_path)
+  with open('/tmp/'+uuid+".txt", 'r') as file:
+    password = file.read().replace('\n', '')
+  print("Instance created, please connect on port 3333 using admin : "+password+" as credentials")
+  print("Once finished, destroy this instance unsing : python3 deploy.py -d "+uuid)

--- a/terraform/aws/data.tf
+++ b/terraform/aws/data.tf
@@ -1,4 +1,5 @@
 # Get the AWS Ubuntu image
+
 data "aws_ami" "ubuntu" {
   most_recent = true
   filter {

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -3,10 +3,10 @@
 
 # Create web server
 resource "aws_instance" "web_server" {
-  ami                    = "${data.aws_ami.ubuntu.id}"
+  ami                    = data.aws_ami.ubuntu.id
   vpc_security_group_ids = ["${aws_security_group.web_server.id}"]
   instance_type          = "t2.micro"
-  key_name               = "${var.ssh_key_name}"
+  key_name               = var.ssh_key_name
   tags = {
     Name = "${terraform.workspace}"
   }
@@ -18,15 +18,15 @@ resource "aws_instance" "web_server" {
 
   connection {
     user        = "ubuntu"
-    host        = "${self.public_ip}"
-    private_key = "${file("~/.ssh/id_rsa")}"
+    host        = self.public_ip
+    private_key = file("~/.ssh/id_rsa")
   }
 
  provisioner "local-exec" {
   command = <<EOT
     sleep 20;
     export ANSIBLE_HOST_KEY_CHECKING=False;
-    ansible-playbook -u ${var.ansible_user}  -i ${aws_instance.web_server.public_ip}, ../../ansible/gophish.yml > /dev/tty
+    ansible-playbook -u ${var.ansible_user}  -i ${aws_instance.web_server.public_ip}, ../../ansible/gophish.yml -e uuid=${terraform.workspace} > /dev/tty
     EOT
    }
   }

--- a/terraform/aws/security-group.tf
+++ b/terraform/aws/security-group.tf
@@ -1,6 +1,6 @@
 # Create security group with web and ssh access
 resource "aws_security_group" "web_server" {
-  name = "${var.server_name}"
+  name = terraform.workspace 
 
   ingress {
     protocol    = "tcp"

--- a/terraform/aws/ssh-key-pair.tf
+++ b/terraform/aws/ssh-key-pair.tf
@@ -1,5 +1,5 @@
 # Deploy ssh key for instance access
 resource "aws_key_pair" "deployer" {
-  key_name   = "${var.ssh_key_name}"
-  public_key = "${file("~/.ssh/id_rsa.pub")}"
+  key_name   = terraform.workspace
+  public_key = file("~/.ssh/id_rsa.pub")
 }

--- a/terraform/aws/vars.tf
+++ b/terraform/aws/vars.tf
@@ -8,7 +8,7 @@ variable ssh_key_name {
   default = "user"
 }
 variable ami {
-  default = "ubuntu/images/hvm-ssd/ubuntu-disco-19.04-amd64-server-*"
+  default = "ubuntu/images/hvm-ssd/ubuntu-eoan-19.10-amd64-server-*"
 }
 variable ansible_user {
   default = "ubuntu"


### PR DESCRIPTION
This PR introduces the deployment of Gophish using Abaddon: it adds the methods necessary. The last step is to makes Abaddon calls theses methods directly using the interface. 
It also solves theses bugs :
- Apt update fails du to depreciated ubuntu distribution
- Depreciated warning du to terraform variables format
- Impossible to deploy multiple Gophish instances at once
- The Gophish password is base64 encoded

The deploy script can also be directly used using the CLI : 
```sh
python3 deploy.py -h
usage: deploy.py [-h] [-a] [-d [DESTROY]]

optional arguments:
  -h, --help            show this help message and exit
  -a, --apply           Create a new Gophish infrastructure
  -d [ec2_uuid], --destroy [ec2_uuid]
                        Destroy a Gophish infra (the ec2_uuid has to be given)
`````
The `terraform/aws/provider.tf` has to be set in order to deploy an instance to AWS.
